### PR TITLE
Update notebook to 4.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.1.0" %}
+{% set version = "4.2.0" %}
 
 package:
   name: notebook
@@ -7,7 +7,7 @@ package:
 source:
   fn: notebook-{{ version }}.tar.gz
   url: https://github.com/jupyter/notebook/archive/{{ version }}.tar.gz
-  sha256: 849f5b67d232163fac69a94ad3078752a1c23b61db630575393b56493a659373
+  sha256: edb7ef8153e5ca781f21c7feb50b3316d515b0d8861ba0e45a00280166214a7f
 
 build:
   script: python setup.py install


### PR DESCRIPTION
See https://blog.jupyter.org/2016/04/15/notebook-4-2/ for the release details.