### PR TITLE
Test jupyter serverextension

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-%PYTHON% setup.py install
-if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   url: https://github.com/jupyter/notebook/archive/{{ version }}.tar.gz
   sha256: edb7ef8153e5ca781f21c7feb50b3316d515b0d8861ba0e45a00280166214a7f
 
+
 build:
   script: python setup.py install
   number: 0
@@ -30,7 +31,7 @@ requirements:
     - nbconvert
     - nbformat
     - python
-    - terminado        # [not win]
+    - terminado  # [not win]
     - tornado >=4
     - traitlets
 
@@ -38,13 +39,14 @@ test:
   commands:
     - jupyter-notebook -h
     - jupyter-nbextension -h
+    - jupyter-serverextension -h
   imports:
     - notebook
 
 about:
   home: http://jupyter.org
   license: BSD 3-clause
-  summary: a web-based notebook environment for interactive computing
+  summary: A web-based notebook environment for interactive computing
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Added a test for `jupyter serverextension`.

I also changed the source to PyPI because the GitHub tag seems to have been altered. (The `sha256` was failing.)

See https://github.com/conda-forge/notebook-feedstock/pull/1#issuecomment-210765721