### PR TITLE
Issues with jupyter bundlerextension on windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ build:
     - jupyter-notebook = notebook.notebookapp:main
     - jupyter-nbextension = notebook.nbextensions:main
     - jupyter-serverextension = notebook.serverextensions:main
+    - jupyter-bundlerextension = notebook.bundler.bundlerextensions:main
 
 requirements:
   build:
@@ -40,6 +41,7 @@ test:
     - jupyter notebook -h
     - jupyter nbextension -h
     - jupyter serverextension -h
+    - jupyter bundlerextension -h
   imports:
     - notebook
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   script: pip install --no-deps .
-  number: 0
+  number: 1
   entry_points:
     - jupyter-notebook = notebook.notebookapp:main
     - jupyter-nbextension = notebook.nbextensions:main


### PR DESCRIPTION
I discovered recently that the command/script `jupyter bundlerextension` is not available or does not work when using a windows machine and the package is installed from _anaconda_ or _conda-forge_ channel.
I build this locally on my windows machine and it seems to work afterwards. So maybe this issue is related to the built process?

However I've added the command/script to the entry points and test commands to be able to see if the build fails.