### PR TITLE
Fix requirements to match those specified in jupyter/notebook

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - nbformat
     - python
     - send2trash
-    - terminado >=0.8.1 # [not win]
+    - terminado >=0.8.1  # [not win]
     - tornado >=4
     - traitlets >=4.2.1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,15 +28,15 @@ requirements:
     - ipykernel
     - ipython_genutils
     - jinja2
-    - jupyter_core
-    - jupyter_client
+    - jupyter_core >=4.4.0
+    - jupyter_client >=5.2.0
     - nbconvert
     - nbformat
     - python
     - send2trash
-    - terminado  # [not win]
+    - terminado >=0.8.1 # [not win]
     - tornado >=4
-    - traitlets >=4.3
+    - traitlets >=4.2.1
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   script:
     - pip install --no-deps .
-  number: 0
+  number: 1
   entry_points:
     - jupyter-notebook = notebook.notebookapp:main
     - jupyter-nbextension = notebook.nbextensions:main


### PR DESCRIPTION
I've recently updated to notebook 5.3.1 of the conda forge channel and got the following error afterwards:
```
ImportError: cannot import name 'ensure_dir_exists'
```
The reason is, I've made an update and the requirement [jupyter_core](https://github.com/jupyter/jupyter_core) is not updated to version 4.4.0.
I compared the requirements in the `setup.py` of [jupyter/notebook](https://github.com/jupyter/notebook) and they are different from those specified in the recipe. I've updated them in the recipe to match those in [jupyter/notebook](https://github.com/jupyter/notebook).