### PR TITLE
Fix terminado requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   script:
     - pip install --no-deps .
-  number: 1
+  number: 2
   entry_points:
     - jupyter-notebook = notebook.notebookapp:main
     - jupyter-nbextension = notebook.nbextensions:main
@@ -34,7 +34,7 @@ requirements:
     - nbformat
     - python
     - send2trash
-    - terminado >=0.8.1  # [not win]
+    - terminado >=0.8.1
     - tornado >=4
     - traitlets >=4.2.1
 


### PR DESCRIPTION
Fixes requirements to match setup.py.

Notebook  [requires terminado >= 0.8.1](https://github.com/jupyter/notebook/blob/5.3.0/setup.py#L90) on all platforms. However, the recipe here [specifies terminado as a requirement only on non-windows platforms](https://github.com/conda-forge/notebook-feedstock/blob/60e4e8d914860b4f195da5336c7f56347677d3b8/recipe/meta.yaml#L37).

Otherwise, having installed notebook through conda on windows, it is possible to have a script which requires notebook fail because terminado is missing. See for example [line #2425 of this appveyor build](https://ci.appveyor.com/project/conda-forge/jupyter-contrib-nbextensions-feedstock/build/1.0.66/job/5656p7axh7jcnr5p#L2425).